### PR TITLE
refs #7 Objective-Cのプリミティブ型をサポートする

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/reverser/LanguageManager.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/reverser/LanguageManager.java
@@ -2,18 +2,35 @@ package com.change_vision.astah.extension.plugin.reverser;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class LanguageManager {
-	public static final String LANGUAGE = "cplus_primitivite_type";
+	
+	private static final String KEY_OF_CPLUS_LANGUAGE = "cplus_primitivite_type";
+	private static final String KEY_OF_OBJECTIVE_C_LANGUAGE = "objc_primitivite_type";
 
-	public final static Set<String> PRIMITIVE_TYPE = new HashSet<String>();
+	public final static Set<String> PRIMITIVE_TYPE;
 
 	static {
+		Config config;
 		try {
-			PRIMITIVE_TYPE.addAll(Arrays.asList(new Config(Config.CONFIG_PROPERTIES).getValue(LANGUAGE).split(",")));
+			config = new Config(Config.CONFIG_PROPERTIES);
 		} catch (IOException e) {
+			throw new IllegalStateException("cannot read config file",e);
 		}
+		Set<String> primitiveTypes = new HashSet<String>(); 
+		loadLanguagePrimitive(config, primitiveTypes, KEY_OF_CPLUS_LANGUAGE);
+		loadLanguagePrimitive(config, primitiveTypes, KEY_OF_OBJECTIVE_C_LANGUAGE);
+		PRIMITIVE_TYPE = Collections.unmodifiableSet(primitiveTypes);
+	}
+
+	private static void loadLanguagePrimitive(Config config, Set<String> primitiveTypes, String key) {
+		String value = config.getValue(key);
+		String[] split = value.split(",");
+		List<String> asList = Arrays.asList(split);
+		primitiveTypes.addAll(asList);
 	}
 }

--- a/src/main/resources/com/change_vision/astah/extension/plugin/reverser/Config.properties
+++ b/src/main/resources/com/change_vision/astah/extension/plugin/reverser/Config.properties
@@ -1,4 +1,5 @@
 java_primitivite_type=boolean,byte,char,double,float,int,long,short,void
 cplus_primitivite_type=bool,char,signed char,unsigned char,short,unsigned short,short int,signed short int,unsigned short int,int,signed int,unsigned int,long,unsigned long,long int,signed long int,unsigned long int,float,double,long double,wchar_t,void
+objc_primitivite_type=int,unsigned int,long,unsigned long,long long,unsigned long long,short,unsigned short,char,unsigned char,float,double,BOOL,NSInteger,NSUInteger,NSDecimal,NSString,id,SEL
 java_types_for_attribute=
 cplus_types_for_attribute=

--- a/src/test/java/com/change_vision/astah/extension/plugin/reverser/LanguageManagerTest.java
+++ b/src/test/java/com/change_vision/astah/extension/plugin/reverser/LanguageManagerTest.java
@@ -1,0 +1,26 @@
+package com.change_vision.astah.extension.plugin.reverser;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class LanguageManagerTest {
+
+	private Set<String> sut;
+
+	@Before
+	public void before() throws Exception {
+		sut = LanguageManager.PRIMITIVE_TYPE;
+	}
+	
+	@Test
+	public void loadPrimitiveFile() {
+		assertThat(sut.contains("int"),is(true));
+		assertThat(sut.contains("NSString"),is(true));
+	}
+
+}


### PR DESCRIPTION
- 設定ファイルにObjective-Cのプリミティブ型を追加
- プリミティブ型をC++とObjective-Cの両方を読込
