### PR TITLE
refs #9 クラスに同じ型のプロパティが複数あると、一つ目が属性になり、２つ目以降が関連端になる

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/reverser/Creator.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/reverser/Creator.java
@@ -500,15 +500,21 @@ public class Creator {
 		} else {
 			if (findClass == null) {
 				if (type.getNamespaceClass() != null && !isEmpty(type.getNamespaceClass().clazz)) {
-					attribute = this.basicModelEditor.createAttribute(clazz, type.getName(), type.getNamespaceClass().clazz);
+					IPackage pkg = this.astahModelUtil.getModelWithPath(IPackage.class, project, type.getNamespaceClass().namespace);
+					if (pkg == null) {
+						pkg = project;
+					}
+					findClass = this.basicModelEditor.createClass(pkg, type.getNamespaceClass().clazz);
+					if (isAssociation) {
+						attribute = this.createAssosiation(clazz, type, findClass);
+						memberEnd = true;
+					} else {
+						attribute = this.basicModelEditor.createAttribute(clazz, type.getName(), findClass);
+					}
 				}
 			} else {
 				if (isAssociation) {
-					IAssociation association = this.basicModelEditor.createAssociation(clazz, findClass, "", "", type.getName());
-					IAttribute[] memberEnds = association.getMemberEnds();
-					attribute = memberEnds[0];
-					memberEnds[1].setNavigability("Navigable");
-					attribute.setNavigability("Non_Navigable");
+					attribute = this.createAssosiation(clazz, type, findClass);
 					memberEnd = true;
 				} else {
 					attribute = this.basicModelEditor.createAttribute(clazz, type.getName(), findClass);
@@ -535,6 +541,17 @@ public class Creator {
 		if (!memberEnd && type.isMutable()) {
 			this.createTaggedValue(attribute, "jude.c_plus.mutable", "true");
 		}
+	}
+
+	private IAttribute createAssosiation(IClass clazz, Type type,
+			IClass findClass) throws InvalidEditingException {
+		IAttribute attribute;
+		IAssociation association = this.basicModelEditor.createAssociation(clazz, findClass, "", "", type.getName());
+		IAttribute[] memberEnds = association.getMemberEnds();
+		attribute = memberEnds[0];
+		memberEnds[1].setNavigability("Navigable");
+		attribute.setNavigability("Non_Navigable");
+		return attribute;
 	}
 
 	public void createGlobalClass(CompounddefType compounddefType) throws InvalidEditingException, ProjectNotFoundException {


### PR DESCRIPTION
- クラスを探して見つからない場合は、先にクラスを作成し、関連端を作成するようにしました。
- 重複するコードをリファクタリングしました。
